### PR TITLE
Fix problem where users couldn't retrieve their own roles

### DIFF
--- a/src/main/kotlin/com/kos/credentials/CredentialsController.kt
+++ b/src/main/kotlin/com/kos/credentials/CredentialsController.kt
@@ -92,7 +92,7 @@ class CredentialsController(val credentialsService: CredentialsService) {
         return when (client) {
             null -> Either.Left(NotAuthorized)
             else -> {
-                if (activities.contains(Activities.getAnyCredential)) {
+                if (activities.contains(Activities.getAnyCredentialsRoles) || (client == user && activities.contains(Activities.getOwnCredentialsRoles) )) {
                     when (val credential = credentialsService.getCredential(user)) {
                         null -> Either.Left(NotFound(user))
                         else -> Either.Right(credential)

--- a/src/main/resources/db/migration/prod/V1734399500__Roles_Activities_Values.sql
+++ b/src/main/resources/db/migration/prod/V1734399500__Roles_Activities_Values.sql
@@ -1,0 +1,1 @@
+insert into roles_activities values('user', 'get own credentials roles');

--- a/src/test/kotlin/com/kos/credentials/CredentialsControllerTest.kt
+++ b/src/test/kotlin/com/kos/credentials/CredentialsControllerTest.kt
@@ -54,7 +54,7 @@ class CredentialsControllerTest {
 
             val controller = createController(basicCredentialsWithRolesInitialState)
             val expected = CredentialsWithRoles(user, listOf(Role.USER))
-            controller.getCredential("owner", setOf(Activities.getAnyCredential), user)
+            controller.getCredential("owner", setOf(Activities.getAnyCredentialsRoles), user)
                 .onLeft { fail(it.toString()) }
                 .onRight { assertEquals(expected, it) }
         }

--- a/src/test/kotlin/com/kos/credentials/CredentialsControllerTest.kt
+++ b/src/test/kotlin/com/kos/credentials/CredentialsControllerTest.kt
@@ -64,7 +64,12 @@ class CredentialsControllerTest {
     fun `i can patch a credential`() {
         runBlocking {
             val controller = createController(basicCredentialsWithRolesInitialState)
-            controller.patchCredential("owner", setOf(Activities.patchCredentials), user, PatchCredentialRequest("new-password", null))
+            controller.patchCredential(
+                "owner",
+                setOf(Activities.patchCredentials),
+                user,
+                PatchCredentialRequest("new-password", null)
+            )
                 .onLeft { fail(it.toString()) }
         }
     }
@@ -132,6 +137,46 @@ class CredentialsControllerTest {
             controller.deleteCredential("owner", setOf(Activities.deleteCredentials), "owner")
                 .onRight { fail("expected failure") }
                 .onLeft { assertTrue(it is CantDeleteYourself) }
+        }
+    }
+
+    @Test
+    fun `i can get any credential with get any credentials roles activity`() {
+        runBlocking {
+            val credentialsState = CredentialsRepositoryState(
+                listOf(basicCredentials.copy(userName = "owner"), basicCredentials),
+                mapOf("owner" to listOf(Role.ADMIN))
+            )
+
+            val expected = CredentialsWithRoles("owner", listOf(Role.ADMIN))
+
+            val controller = createController(credentialsState)
+
+            controller.getCredential("admin", setOf(Activities.getAnyCredentialsRoles), "owner")
+                .onRight { assertEquals(expected, it) }
+                .onLeft { fail(it.toString()) }
+        }
+    }
+
+    @Test
+    fun `i can get only my credential with get own credentials roles activity`() {
+        runBlocking {
+            val credentialsState = CredentialsRepositoryState(
+                listOf(basicCredentials.copy(userName = "owner"), basicCredentials),
+                mapOf("owner" to listOf(Role.ADMIN), user to listOf(Role.USER))
+            )
+
+            val expected = CredentialsWithRoles("user", listOf(Role.USER))
+
+            val controller = createController(credentialsState)
+
+            controller.getCredential("user", setOf(Activities.getOwnCredentialsRoles), "owner")
+                .onRight { fail() }
+                .onLeft { assertTrue(it is NotEnoughPermissions) }
+
+            controller.getCredential("user", setOf(Activities.getOwnCredentialsRoles), "user")
+                .onRight { assertEquals(it, expected) }
+                .onLeft { fail(it.toString()) }
         }
     }
 


### PR DESCRIPTION
### Description

Users can now retrieve their own roles by using the GET /credentials/themselves

### Checklist

- [x] I didn't add a changelog entry because this feature didn't need to update changelog
- [ ] I didn't add a single test because this feature didn't require unit testing
- [x] I have tested this feature in an environment (e.g., production, development, local)

*Please ensure you’ve met all the necessary criteria before submitting.*

---

*If the changelog checkbox is not checked, make sure to add an entry in `CHANGELOG.md`.*

*If the unit testing is not checked, make sure to add unit tests in `/src/test/kotlin`.*