### PR TITLE
feature - add pagination to get views endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [4.2.3] 17-12-2024
+- **Limit and pagination added for Get Views Endpoint**:
+
 ## [4.2.2] 15-12-2024
 
 ### Added

--- a/src/main/kotlin/com/kos/views/ViewsController.kt
+++ b/src/main/kotlin/com/kos/views/ViewsController.kt
@@ -11,11 +11,15 @@ class ViewsController(
     private val viewsService: ViewsService,
 ) {
 
-    suspend fun getViews(client: String?, activities: Set<Activity>, game: Game?): Either<ControllerError, List<SimpleView>> {
+    suspend fun getViews(client: String?,
+                         activities: Set<Activity>,
+                         game: Game?,
+                         page: Int?,
+                         limit: Int?): Either<ControllerError, List<SimpleView>> {
         return when (client) {
             null -> Either.Left(NotAuthorized)
             else -> {
-                if (activities.contains(Activities.getAnyViews)) Either.Right(viewsService.getViews(game))
+                if (activities.contains(Activities.getAnyViews)) Either.Right(viewsService.getViews(game, page, limit))
                 else if (activities.contains(Activities.getOwnViews)) Either.Right(viewsService.getOwnViews(client))
                 else Either.Left(NotEnoughPermissions(client))
             }

--- a/src/main/kotlin/com/kos/views/ViewsRoutes.kt
+++ b/src/main/kotlin/com/kos/views/ViewsRoutes.kt
@@ -5,7 +5,6 @@ import com.kos.common.InvalidQueryParameter
 import com.kos.common.recoverToEither
 import com.kos.common.respondWithHandledError
 import com.kos.plugins.UserWithActivities
-import io.ktor.http.*
 import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
@@ -25,11 +24,25 @@ fun Route.viewsRouting(
                     val gameTypeParameter = "game"
                     val game: Game? =
                         call.request.queryParameters[gameTypeParameter].recoverToEither(
-                            { InvalidQueryParameter(gameTypeParameter, it, Game.entries.map { games -> games.toString() }) },
+                            {
+                                InvalidQueryParameter(
+                                    gameTypeParameter,
+                                    it,
+                                    Game.entries.map { games -> games.toString() })
+                            },
                             { Game.fromString(it) }
                         ).bind()
 
-                    viewsController.getViews(userWithActivities?.name, userWithActivities?.activities.orEmpty(), game).bind()
+                    val page = call.request.queryParameters["pagination"]?.toInt()
+                    val limit = call.request.queryParameters["limit"]?.toInt()
+
+                    viewsController.getViews(
+                        userWithActivities?.name,
+                        userWithActivities?.activities.orEmpty(),
+                        game,
+                        page,
+                        limit
+                    ).bind()
                 }.fold({
                     call.respondWithHandledError(it)
                 }, {

--- a/src/main/kotlin/com/kos/views/ViewsService.kt
+++ b/src/main/kotlin/com/kos/views/ViewsService.kt
@@ -22,7 +22,9 @@ class ViewsService(
 ) {
 
     suspend fun getOwnViews(owner: String): List<SimpleView> = viewsRepository.getOwnViews(owner)
-    suspend fun getViews(game: Game?, featured: Boolean, page: Int?, limit: Int?): List<SimpleView> = viewsRepository.getViews(game, featured, page, limit)
+    suspend fun getViews(game: Game?, featured: Boolean, page: Int?, limit: Int?): List<SimpleView> =
+        viewsRepository.getViews(game, featured, page, limit)
+
     suspend fun get(id: String): View? {
         return when (val simpleView = viewsRepository.get(id)) {
             null -> null

--- a/src/main/kotlin/com/kos/views/ViewsService.kt
+++ b/src/main/kotlin/com/kos/views/ViewsService.kt
@@ -4,12 +4,12 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.kos.characters.CharactersService
+import com.kos.clients.domain.Data
 import com.kos.common.*
 import com.kos.credentials.CredentialsService
 import com.kos.datacache.DataCacheService
 import com.kos.eventsourcing.events.*
 import com.kos.eventsourcing.events.repository.EventStore
-import com.kos.clients.domain.Data
 import com.kos.views.repository.ViewsRepository
 import java.util.*
 
@@ -22,7 +22,9 @@ class ViewsService(
 ) {
 
     suspend fun getOwnViews(owner: String): List<SimpleView> = viewsRepository.getOwnViews(owner)
-    suspend fun getViews(game: Game?): List<SimpleView> = viewsRepository.getViews(game)
+    suspend fun getViews(game: Game?, page: Int?, limit: Int?): List<SimpleView> =
+        viewsRepository.getViews(game, page, limit)
+
     suspend fun get(id: String): View? {
         return when (val simpleView = viewsRepository.get(id)) {
             null -> null
@@ -177,7 +179,7 @@ class ViewsService(
             val event = Event(
                 aggregateRoot,
                 operationId,
-                ViewPatchedEvent.fromViewPatched(operationId,viewToBePatchedEvent.game, patchedView)
+                ViewPatchedEvent.fromViewPatched(operationId, viewToBePatchedEvent.game, patchedView)
             )
             eventStore.save(event)
         }

--- a/src/main/kotlin/com/kos/views/repository/ViewsDatabaseRepository.kt
+++ b/src/main/kotlin/com/kos/views/repository/ViewsDatabaseRepository.kt
@@ -133,16 +133,37 @@ class ViewsDatabaseRepository(private val db: Database) : ViewsRepository {
         return ViewDeleted(id)
     }
 
-    override suspend fun getViews(game: Game?): List<SimpleView> {
+    // offset (page * limit), limit (limit)
+    override suspend fun getViews(game: Game?, page: Int?, limit: Int?): List<SimpleView> {
         return newSuspendedTransaction(Dispatchers.IO, db) {
             val baseQuery = Views.selectAll()
+
             val filteredQuery = game.fold(
                 { baseQuery },
                 { baseQuery.adjustWhere { Views.game eq it.toString() } }
             )
-            filteredQuery.map { resultRowToSimpleView(it) }
+            filteredQuery
+                .map { resultRowToSimpleView(it) }
         }
     }
+
+//    override suspend fun getViews(game: Game?, page: Int?, limit: Int?): List<SimpleView> {
+//        return newSuspendedTransaction(Dispatchers.IO, db) {
+//            val baseQuery = Views.selectAll()
+//
+//            val filteredQuery = game.fold(
+//                { baseQuery },
+//                { baseQuery.adjustWhere { Views.game eq it.toString() } }
+//            )
+//
+//            val paginatedQuery = filteredQuery
+//                .let { query ->
+//                    limit?.let { query.limit(it, offset = ((page ?: 1) - 1) * it) } ?: query
+//                }
+//
+//            paginatedQuery.map { resultRowToSimpleView(it) }
+//        }
+//    }
 
     override suspend fun state(): List<SimpleView> {
         return newSuspendedTransaction(Dispatchers.IO, db) { Views.selectAll().map { resultRowToSimpleView(it) } }

--- a/src/main/kotlin/com/kos/views/repository/ViewsInMemoryRepository.kt
+++ b/src/main/kotlin/com/kos/views/repository/ViewsInMemoryRepository.kt
@@ -60,9 +60,15 @@ class ViewsInMemoryRepository : ViewsRepository, InMemoryRepository {
     override suspend fun getViews(game: Game?, page: Int?, limit: Int?): List<SimpleView> {
         val allViews = views.toList()
 
-        return game.fold(
-            { allViews },
-            { views.filter { it.game == game } }
+        val filteredQuery =
+            game.fold(
+                { allViews },
+                { views.filter { it.game == game } }
+            )
+
+        return limit.fold(
+            { filteredQuery },
+            { filteredQuery.drop(((page ?: 1) - 1) * it).take(it) }
         )
     }
 

--- a/src/main/kotlin/com/kos/views/repository/ViewsInMemoryRepository.kt
+++ b/src/main/kotlin/com/kos/views/repository/ViewsInMemoryRepository.kt
@@ -57,7 +57,7 @@ class ViewsInMemoryRepository : ViewsRepository, InMemoryRepository {
         return ViewDeleted(id)
     }
 
-    override suspend fun getViews(game: Game?): List<SimpleView> {
+    override suspend fun getViews(game: Game?, page: Int?, limit: Int?): List<SimpleView> {
         val allViews = views.toList()
 
         return game.fold(

--- a/src/main/kotlin/com/kos/views/repository/ViewsRepository.kt
+++ b/src/main/kotlin/com/kos/views/repository/ViewsRepository.kt
@@ -10,5 +10,5 @@ interface ViewsRepository : WithState<List<SimpleView>, ViewsRepository> {
     suspend fun edit(id: String, name: String, published: Boolean, characters: List<Long>): ViewModified
     suspend fun patch(id: String, name: String?, published: Boolean?, characters: List<Long>?): ViewPatched
     suspend fun delete(id: String): ViewDeleted
-    suspend fun getViews(game: Game?): List<SimpleView>
+    suspend fun getViews(game: Game?, page: Int?, limit: Int?): List<SimpleView>
 }

--- a/src/test/kotlin/com/kos/views/ViewsControllerTest.kt
+++ b/src/test/kotlin/com/kos/views/ViewsControllerTest.kt
@@ -32,6 +32,7 @@ import com.kos.eventsourcing.events.EventType
 import com.kos.eventsourcing.events.repository.EventStoreInMemory
 import com.kos.roles.Role
 import com.kos.roles.repository.RolesActivitiesInMemoryRepository
+import com.kos.views.ViewsTestHelper.basicSimpleGameViews
 import com.kos.views.ViewsTestHelper.basicSimpleLolView
 import com.kos.views.ViewsTestHelper.basicSimpleWowView
 import com.kos.views.ViewsTestHelper.owner
@@ -95,6 +96,45 @@ class ViewsControllerTest {
     }
 
     @Test
+    fun `i can get views returns only one view since the limit is 1`() {
+        runBlocking {
+            val limit = 1
+
+            val controller = createController(
+                emptyCredentialsState,
+                basicSimpleGameViews,
+                emptyCharactersState,
+                listOf()
+            )
+            assertEquals(
+                limit,
+                controller.getViews("owner", setOf(Activities.getAnyViews), Game.WOW, true, null, limit)
+                    .getOrNull()?.size
+            )
+        }
+    }
+
+    @Test
+    fun `i can get views returns empty since the pagination and limit goes beyond actual rows in database`() {
+        runBlocking {
+            val limit = 10
+            val pagination = 2
+
+            val controller = createController(
+                emptyCredentialsState,
+                basicSimpleGameViews,
+                emptyCharactersState,
+                listOf()
+            )
+            assertEquals(
+                0,
+                controller.getViews("owner", setOf(Activities.getAnyViews), Game.WOW, true, pagination, limit)
+                    .getOrNull()?.size
+            )
+        }
+    }
+
+    @Test
     fun `i can get views returns only wow featured views`() {
         runBlocking {
             val featuredView = basicSimpleWowView.copy(featured = true)
@@ -107,7 +147,7 @@ class ViewsControllerTest {
             )
             assertEquals(
                 listOf(featuredView),
-                controller.getViews("owner", setOf(Activities.getAnyViews), Game.WOW, true).getOrNull()
+                controller.getViews("owner", setOf(Activities.getAnyViews), Game.WOW, true, null, null).getOrNull()
             )
         }
     }
@@ -123,7 +163,7 @@ class ViewsControllerTest {
             )
             assertEquals(
                 listOf(basicSimpleWowView),
-                controller.getViews("owner", setOf(Activities.getOwnViews), null, false).getOrNull()
+                controller.getViews("owner", setOf(Activities.getOwnViews), null, false, null, null).getOrNull()
             )
         }
     }
@@ -140,7 +180,7 @@ class ViewsControllerTest {
             )
             assertEquals(
                 listOf(basicSimpleWowView, notOwnerView),
-                controller.getViews("owner", setOf(Activities.getAnyViews), null, false).getOrNull()
+                controller.getViews("owner", setOf(Activities.getAnyViews), null, false, null, null).getOrNull()
             )
         }
     }

--- a/src/test/kotlin/com/kos/views/ViewsRepositoryTest.kt
+++ b/src/test/kotlin/com/kos/views/ViewsRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.kos.views.ViewsTestHelper.basicSimpleLolView
 import com.kos.views.ViewsTestHelper.basicSimpleLolViews
 import com.kos.views.ViewsTestHelper.basicSimpleWowView
 import com.kos.views.ViewsTestHelper.featured
+import com.kos.views.ViewsTestHelper.gigaSimpleGameViews
 import com.kos.views.ViewsTestHelper.id
 import com.kos.views.ViewsTestHelper.name
 import com.kos.views.ViewsTestHelper.owner
@@ -30,7 +31,7 @@ abstract class ViewsRepositoryTest {
     fun `given a repository with views i can retrieve the views of a game`() {
         runBlocking {
             val repositoryWithState = repository.withState(basicSimpleGameViews)
-            assertEquals(basicSimpleLolViews, repositoryWithState.getViews(Game.LOL, featured))
+            assertEquals(basicSimpleLolViews, repositoryWithState.getViews(Game.LOL, featured, null, null))
         }
     }
 
@@ -40,10 +41,36 @@ abstract class ViewsRepositoryTest {
             val repositoryWithState = repository.withState(basicSimpleGameViews)
             assertEquals(
                 listOf(basicSimpleWowView.copy(id = "3", featured = true)),
-                repositoryWithState.getViews(Game.WOW, true)
+                repositoryWithState.getViews(Game.WOW, true, null, null)
             )
         }
     }
+
+    @Test
+    fun `i can get views returns only one view since the limit is 1`() {
+        runBlocking {
+            val limit = 1
+            val repositoryWithState = repository.withState(gigaSimpleGameViews)
+            assertEquals(
+                listOf(basicSimpleLolView),
+                repositoryWithState.getViews(Game.LOL, false, null, limit)
+            )
+        }
+    }
+
+    @Test
+    fun `i can get views returns empty since the pagination and limit goes beyond actual rows in database`() {
+        runBlocking {
+            val pagination = 2
+            val limit = 5
+            val repositoryWithState = repository.withState(gigaSimpleGameViews)
+            assertEquals(
+                gigaSimpleGameViews.takeLast(4),
+                repositoryWithState.getViews(null, false, pagination, limit)
+            )
+        }
+    }
+
 
     @Test
     fun `i can get views returns all featured views`() {
@@ -54,7 +81,7 @@ abstract class ViewsRepositoryTest {
             val repositoryWithState = repository.withState(basicSimpleGameViews.plus(featuredLolView))
             assertEquals(
                 listOf(featuredWowView, featuredLolView),
-                repositoryWithState.getViews(null, true)
+                repositoryWithState.getViews(null, true, null, null)
             )
         }
     }

--- a/src/test/kotlin/com/kos/views/ViewsServiceTest.kt
+++ b/src/test/kotlin/com/kos/views/ViewsServiceTest.kt
@@ -92,6 +92,43 @@ class ViewsServiceTest {
         }
 
         @Test
+        fun `i can get views returns only one view since the limit is 1`() {
+            runBlocking {
+                val limit = 1
+
+                val (_, viewsService) = createService(
+                    basicSimpleGameViews,
+                    emptyCharactersState,
+                    listOf(),
+                    emptyCredentialsInitialState
+                )
+                assertEquals(
+                    limit,
+                    viewsService.getViews(Game.WOW, false, null, limit).size
+                )
+            }
+        }
+
+        @Test
+        fun `i can get views returns empty since the pagination and limit goes beyond actual rows in database`() {
+            runBlocking {
+                val pagination = 2
+                val limit = 10
+
+                val (_, viewsService) = createService(
+                    basicSimpleGameViews,
+                    emptyCharactersState,
+                    listOf(),
+                    emptyCredentialsInitialState
+                )
+                assertEquals(
+                    0,
+                    viewsService.getViews(Game.WOW, false, pagination, limit).size
+                )
+            }
+        }
+
+        @Test
         fun `i can get a simple view`() {
             runBlocking {
                 val (_, viewsService) = createService(
@@ -115,7 +152,7 @@ class ViewsServiceTest {
                     emptyCredentialsInitialState
                 )
 
-                assertEquals(basicSimpleLolViews, viewsService.getViews(Game.LOL, false))
+                assertEquals(basicSimpleLolViews, viewsService.getViews(Game.LOL, false, null, null))
             }
         }
 
@@ -131,7 +168,7 @@ class ViewsServiceTest {
 
                 assertEquals(
                     listOf(basicSimpleWowView.copy(id = "3", featured = true)),
-                    viewsService.getViews(Game.WOW, true)
+                    viewsService.getViews(Game.WOW, true, null, null)
                 )
             }
         }

--- a/src/test/kotlin/com/kos/views/ViewsTestHelper.kt
+++ b/src/test/kotlin/com/kos/views/ViewsTestHelper.kt
@@ -18,6 +18,16 @@ object ViewsTestHelper {
         basicSimpleLolView.copy(id = "2"),
         basicSimpleWowView.copy(id = "3", featured = true)
     )
+    val gigaSimpleGameViews =
+        basicSimpleGameViews +
+                listOf(
+                    basicSimpleLolView.copy(id = "4", featured = false),
+                    basicSimpleLolView.copy(id = "5", featured = true),
+                    basicSimpleWowView.copy(id = "6", featured = true),
+                    basicSimpleWowView.copy(id = "7", featured = false),
+                    basicSimpleWowView.copy(id = "8", game = Game.WOW_HC, featured = false),
+                    basicSimpleWowView.copy(id = "9", game = Game.WOW_HC, featured = true)
+                )
 }
 
 fun View.toSimple() =


### PR DESCRIPTION
### Description

Basically in the get views endpoints we can receive two new parameters, limit and page that will paginate over get results returned from views repository when calling get views

### Checklist

- [ ] I didn't add a changelog entry because this feature didn't need to update changelog
- [ ] I didn't add a single test because this feature didn't require unit testing
- [ ] I have tested this feature in an environment (e.g., production, development, local)

*Please ensure you’ve met all the necessary criteria before submitting.*

---

*If the changelog checkbox is not checked, make sure to add an entry in `CHANGELOG.md`.*

*If the unit testing is not checked, make sure to add unit tests in `/src/test/kotlin`.*