### PR TITLE
techDebt/do_not_fetch_cached_runs_wow_sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## [5.2.0] - 17-04-2026
+
+### Improved
+- **`WowEntitySynchronizer` avoids redundant `getRunDetails` calls across syncs**:
+    - `RunDetails` (roster composition, death logs) for a Mythic+ run don't change between syncs. Previously, every synchronization called `raiderIoClient.getRunDetails` for every best run of every character unconditionally.
+    - The synchronizer now loads the most recent cached `RaiderIoData` for each entity before enriching runs. Runs already present in the persistent cache skip the third-party call entirely and reuse the stored details.
+    - Runs not found in the persistent cache are still fetched via the existing `DynamicCache`, which deduplicates requests within a single sync for runs shared across multiple entities.
+
 ## [5.1.0] - 02-04-2026
 
 ### Added

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -140,9 +140,9 @@ class WowEntitySynchronizer(
         val cachedRunIds = newestDataCacheEntry?.mythicPlusBestRuns
             ?.map { it.run.runId }?.toSet().orEmpty()
 
-        val newIds = responseRuns.filterNot { it.runId in cachedRunIds }
+        val uncachedRuns = responseRuns.filterNot { it.runId in cachedRunIds }
 
-        val fetchedRunDetails: Map<Long, RunDetails?> = newIds.associate { run ->
+        val fetchedRunDetails: Map<Long, RunDetails?> = uncachedRuns.associate { run ->
             run.runId to runDetailsCache.get(run.runId.toString()) {
                 executeClientCall("raiderIoGetRunDetails") {
                     raiderIoClient.getRunDetails(currentSeasonSlug, run.runId.toString())

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -161,7 +161,7 @@ class WowEntitySynchronizer(
             ?.associate { it.run.runId to it.details }
             .orEmpty()
 
-        logger.debug("Found ${cachedRunDetails.size} cached run details: $cachedRunDetails")
+        logger.debug("Not requesting ${cachedRunDetails.size} run details because they are already cached");
 
         return responseRuns.map { run ->
             EnrichedMythicPlusRun(run, fetchedRunDetails[run.runId] ?: cachedRunDetails[run.runId])

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -69,9 +69,14 @@ class WowEntitySynchronizer(
                 }.split()
 
                 val data = profiles.parMap { (entityId, raiderIoResponse) ->
+                    val newestDataCacheEntry: RaiderIoData? = getNewestDataCacheEntry(entityId)
                     val quantile = getQuantile(cutoff, raiderIoResponse)
-                    val enrichedRuns =
-                        fetchRunDetails(raiderIoResponse.profile.mythicPlusBestRuns, currentSeasonSlug, runDetailsCache)
+                    val enrichedRuns = fetchRunDetails(
+                        raiderIoResponse.profile.mythicPlusBestRuns,
+                        currentSeasonSlug,
+                        runDetailsCache,
+                        newestDataCacheEntry
+                    )
 
                     DataCache(
                         entityId,
@@ -97,6 +102,22 @@ class WowEntitySynchronizer(
             syncResult.fold({ listOf(it) }, { it })
         }
 
+    private suspend fun getNewestDataCacheEntry(entityId: Long): RaiderIoData? =
+        dataCacheRepository.get(entityId)
+            .filter { it.game == Game.WOW }
+            .maxByOrNull { it.inserted }
+            ?.let {
+                try {
+                    json.decodeFromString<RaiderIoData>(it.data)
+                } catch (e: Throwable) {
+                    logger.debug(
+                        "Couldn't deserialize entity $entityId " +
+                                "while trying to obtain newest cached record.\n${e.message}"
+                    )
+                    null
+                }
+            }
+
     private fun getQuantile(
         cutoff: RaiderIoCutoff?,
         raiderIoResponse: RaiderIoResponse
@@ -107,25 +128,42 @@ class WowEntitySynchronizer(
     }
 
     private suspend fun fetchRunDetails(
-        runs: List<MythicPlusRun>,
+        fetchedRuns: List<MythicPlusRun>,
         currentSeasonSlug: String?,
-        runDetailsCache: DynamicCache<Either<ServiceError, RunDetails>>
+        runDetailsCache: DynamicCache<Either<ServiceError, RunDetails>>,
+        newestDataCacheEntry: RaiderIoData?
     ): List<EnrichedMythicPlusRun> {
         if (currentSeasonSlug == null) {
-            return runs.map { EnrichedMythicPlusRun(it, null) }
+            return fetchedRuns.map { EnrichedMythicPlusRun(it, null) }
         }
-        return runs.map { run ->
-            runDetailsCache.get(run.runId.toString()) {
+
+        val currentRunIds = fetchedRuns.map { it.runId }.toSet()
+        val cachedRunIds = newestDataCacheEntry?.mythicPlusBestRuns
+            ?.map { it.run.runId }?.toSet().orEmpty()
+
+        val newIds = fetchedRuns.filterNot { it.runId in cachedRunIds }
+
+        val fetchedRunDetails: Map<Long, RunDetails?> = newIds.associate { run ->
+            run.runId to runDetailsCache.get(run.runId.toString()) {
                 executeClientCall("raiderIoGetRunDetails") {
                     raiderIoClient.getRunDetails(currentSeasonSlug, run.runId.toString())
                 }
             }.fold(
                 ifLeft = { error ->
                     logger.warn("Failed to fetch run details for runId=${run.runId}: ${error.error()}")
-                    EnrichedMythicPlusRun(run, null)
+                    null
                 },
-                ifRight = { details -> EnrichedMythicPlusRun(run, details) }
+                ifRight = { it }
             )
+        }
+
+        val cachedRunDetails: Map<Long, RunDetails?> = newestDataCacheEntry?.mythicPlusBestRuns
+            ?.filter { it.run.runId in currentRunIds }
+            ?.associate { it.run.runId to it.details }
+            .orEmpty()
+
+        return fetchedRuns.map { run ->
+            EnrichedMythicPlusRun(run, fetchedRunDetails[run.runId] ?: cachedRunDetails[run.runId])
         }
     }
 

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -104,7 +104,6 @@ class WowEntitySynchronizer(
 
     private suspend fun getNewestDataCacheEntry(entityId: Long): RaiderIoData? =
         dataCacheRepository.get(entityId)
-            .filter { it.game == Game.WOW }
             .maxByOrNull { it.inserted }
             ?.let {
                 try {
@@ -161,6 +160,8 @@ class WowEntitySynchronizer(
             ?.filter { it.run.runId in responseRunIds }
             ?.associate { it.run.runId to it.details }
             .orEmpty()
+
+        logger.debug("Found ${cachedRunDetails.size} cached run details: $cachedRunDetails")
 
         return responseRuns.map { run ->
             EnrichedMythicPlusRun(run, fetchedRunDetails[run.runId] ?: cachedRunDetails[run.runId])

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -136,8 +136,10 @@ class WowEntitySynchronizer(
             return responseRuns.map { EnrichedMythicPlusRun(it, null) }
         }
 
-        val responseRunIds = responseRuns.map { it.runId }.toSet()
+        val responseRunIds = responseRuns
+            .map { it.runId }.toSet()
         val cachedRunIds = newestDataCacheEntry?.mythicPlusBestRuns
+            ?.filter { it.details != null }
             ?.map { it.run.runId }?.toSet().orEmpty()
 
         val uncachedRuns = responseRuns.filterNot { it.runId in cachedRunIds }

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -161,7 +161,7 @@ class WowEntitySynchronizer(
             ?.associate { it.run.runId to it.details }
             .orEmpty()
 
-        logger.debug("Not requesting ${cachedRunDetails.size} run details because they are already cached");
+        logger.debug("Not requesting ${cachedRunDetails.size} run details because they are already cached")
 
         return responseRuns.map { run ->
             EnrichedMythicPlusRun(run, fetchedRunDetails[run.runId] ?: cachedRunDetails[run.runId])

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -128,20 +128,20 @@ class WowEntitySynchronizer(
     }
 
     private suspend fun fetchRunDetails(
-        fetchedRuns: List<MythicPlusRun>,
+        responseRuns: List<MythicPlusRun>,
         currentSeasonSlug: String?,
         runDetailsCache: DynamicCache<Either<ServiceError, RunDetails>>,
         newestDataCacheEntry: RaiderIoData?
     ): List<EnrichedMythicPlusRun> {
         if (currentSeasonSlug == null) {
-            return fetchedRuns.map { EnrichedMythicPlusRun(it, null) }
+            return responseRuns.map { EnrichedMythicPlusRun(it, null) }
         }
 
-        val currentRunIds = fetchedRuns.map { it.runId }.toSet()
+        val responseRunIds = responseRuns.map { it.runId }.toSet()
         val cachedRunIds = newestDataCacheEntry?.mythicPlusBestRuns
             ?.map { it.run.runId }?.toSet().orEmpty()
 
-        val newIds = fetchedRuns.filterNot { it.runId in cachedRunIds }
+        val newIds = responseRuns.filterNot { it.runId in cachedRunIds }
 
         val fetchedRunDetails: Map<Long, RunDetails?> = newIds.associate { run ->
             run.runId to runDetailsCache.get(run.runId.toString()) {
@@ -158,11 +158,11 @@ class WowEntitySynchronizer(
         }
 
         val cachedRunDetails: Map<Long, RunDetails?> = newestDataCacheEntry?.mythicPlusBestRuns
-            ?.filter { it.run.runId in currentRunIds }
+            ?.filter { it.run.runId in responseRunIds }
             ?.associate { it.run.runId to it.details }
             .orEmpty()
 
-        return fetchedRuns.map { run ->
+        return responseRuns.map { run ->
             EnrichedMythicPlusRun(run, fetchedRunDetails[run.runId] ?: cachedRunDetails[run.runId])
         }
     }

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -19,6 +19,7 @@ import com.kos.entities.domain.WowEntity
 import com.kos.sources.wow.staticdata.wowseason.repository.WowSeasonRepository
 import com.kos.views.Game
 import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
@@ -108,7 +109,7 @@ class WowEntitySynchronizer(
             ?.let {
                 try {
                     json.decodeFromString<RaiderIoData>(it.data)
-                } catch (e: Throwable) {
+                } catch (e: SerializationException) {
                     logger.debug(
                         "Couldn't deserialize entity $entityId " +
                                 "while trying to obtain newest cached record.\n${e.message}"

--- a/src/test/kotlin/com/kos/sources/wow/WowEntitySynchronizerTest.kt
+++ b/src/test/kotlin/com/kos/sources/wow/WowEntitySynchronizerTest.kt
@@ -2,15 +2,7 @@ package com.kos.sources.wow
 
 import arrow.core.Either
 import com.kos.clients.HttpError
-import com.kos.clients.domain.EnrichedMythicPlusRun
-import com.kos.clients.domain.MythicPlusRank
-import com.kos.clients.domain.MythicPlusRanks
-import com.kos.clients.domain.MythicPlusRun
-import com.kos.clients.domain.MythicPlusSeasonScore
-import com.kos.clients.domain.RaiderIoData
-import com.kos.clients.domain.RaiderIoProfile
-import com.kos.clients.domain.RaiderIoResponse
-import com.kos.clients.domain.SeasonScores
+import com.kos.clients.domain.*
 import com.kos.clients.raiderio.RaiderIoHttpClientHelper
 import com.kos.datacache.RaiderIoMockHelper
 import com.kos.entities.EntitiesTestHelper
@@ -28,9 +20,7 @@ import com.kos.views.ViewsTestHelper.owner
 import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
+import org.mockito.Mockito.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -45,7 +35,8 @@ class WowEntitySynchronizerTest : SyncGameCharactersTestCommon() {
 
     @Test
     fun `wowEntitySynchronizer calls cache on VIEW_CREATED with WOW game`() = runBlocking {
-        `when`(raiderIoClient.cutoff(season.slug)).thenReturn(RaiderIoMockHelper.cutoff())
+        `when`(raiderIoClient.cutoff(season.slug))
+            .thenReturn(RaiderIoMockHelper.cutoff())
         `when`(raiderIoClient.get(EntitiesTestHelper.basicWowEntity))
             .thenReturn(RaiderIoMockHelper.get(EntitiesTestHelper.basicWowEntity))
 
@@ -236,7 +227,14 @@ class WowEntitySynchronizerTest : SyncGameCharactersTestCommon() {
 
         `when`(raiderIoClient.cutoff(season.slug)).thenReturn(RaiderIoMockHelper.cutoff())
         `when`(raiderIoClient.get(EntitiesTestHelper.basicWowEntity))
-            .thenReturn(Either.Right(buildResponseWithRuns(EntitiesTestHelper.basicWowEntity, recentRuns = listOf(recentRun))))
+            .thenReturn(
+                Either.Right(
+                    buildResponseWithRuns(
+                        EntitiesTestHelper.basicWowEntity,
+                        recentRuns = listOf(recentRun)
+                    )
+                )
+            )
 
         val (_, dataCacheRepository) = createService()
         WowEntitySynchronizer(dataCacheRepository, raiderIoClient, wowSeasonRepository())
@@ -251,24 +249,23 @@ class WowEntitySynchronizerTest : SyncGameCharactersTestCommon() {
         val run = RaiderIoHttpClientHelper.mythicPlusRun
         val runDetails = RaiderIoHttpClientHelper.runDetails
 
-        `when`(raiderIoClient.cutoff(season.slug)).thenReturn(RaiderIoMockHelper.cutoff())
+        `when`(raiderIoClient.cutoff(season.slug))
+            .thenReturn(RaiderIoMockHelper.cutoff())
         `when`(raiderIoClient.get(EntitiesTestHelper.basicWowEntity))
             .thenReturn(Either.Right(buildResponseWithRuns(EntitiesTestHelper.basicWowEntity, listOf(run))))
 
         val (_, dataCacheRepository) = createService()
 
-        // First sync — populates the persistent cache with run details
         `when`(raiderIoClient.getRunDetails(season.slug, run.runId.toString()))
             .thenReturn(Either.Right(runDetails))
         WowEntitySynchronizer(dataCacheRepository, raiderIoClient, wowSeasonRepository())
             .synchronize(listOf(EntitiesTestHelper.basicWowEntity))
 
-        // Second sync — same run is still in the profile, details already cached
         WowEntitySynchronizer(dataCacheRepository, raiderIoClient, wowSeasonRepository())
             .synchronize(listOf(EntitiesTestHelper.basicWowEntity))
 
-        // getRunDetails should have been called exactly once across both syncs
-        verify(raiderIoClient, times(1)).getRunDetails(season.slug, run.runId.toString())
+        verify(raiderIoClient, times(1))
+            .getRunDetails(season.slug, run.runId.toString())
 
         val cached = getCachedData(dataCacheRepository, EntitiesTestHelper.basicWowEntity.id)
         assertEquals(EnrichedMythicPlusRun(run, runDetails), cached.mythicPlusBestRuns.first())
@@ -311,7 +308,12 @@ class WowEntitySynchronizerTest : SyncGameCharactersTestCommon() {
 
     private val decodeJson = Json { ignoreUnknownKeys = true }
 
-    private suspend fun getCachedData(dataCacheRepository: com.kos.datacache.repository.DataCacheRepository, entityId: Long): RaiderIoData =
-        decodeJson.decodeFromString(dataCacheRepository.get(entityId).first().data)
+    private suspend fun getCachedData(
+        dataCacheRepository: com.kos.datacache.repository.DataCacheRepository,
+        entityId: Long
+    ): RaiderIoData =
+        decodeJson.decodeFromString(
+            dataCacheRepository.get(entityId).maxBy { it.inserted }.data
+        )
 
 }

--- a/src/test/kotlin/com/kos/sources/wow/WowEntitySynchronizerTest.kt
+++ b/src/test/kotlin/com/kos/sources/wow/WowEntitySynchronizerTest.kt
@@ -247,6 +247,34 @@ class WowEntitySynchronizerTest : SyncGameCharactersTestCommon() {
     }
 
     @Test
+    fun `getRunDetails is not called when run details are already in the persistent cache`() = runBlocking {
+        val run = RaiderIoHttpClientHelper.mythicPlusRun
+        val runDetails = RaiderIoHttpClientHelper.runDetails
+
+        `when`(raiderIoClient.cutoff(season.slug)).thenReturn(RaiderIoMockHelper.cutoff())
+        `when`(raiderIoClient.get(EntitiesTestHelper.basicWowEntity))
+            .thenReturn(Either.Right(buildResponseWithRuns(EntitiesTestHelper.basicWowEntity, listOf(run))))
+
+        val (_, dataCacheRepository) = createService()
+
+        // First sync — populates the persistent cache with run details
+        `when`(raiderIoClient.getRunDetails(season.slug, run.runId.toString()))
+            .thenReturn(Either.Right(runDetails))
+        WowEntitySynchronizer(dataCacheRepository, raiderIoClient, wowSeasonRepository())
+            .synchronize(listOf(EntitiesTestHelper.basicWowEntity))
+
+        // Second sync — same run is still in the profile, details already cached
+        WowEntitySynchronizer(dataCacheRepository, raiderIoClient, wowSeasonRepository())
+            .synchronize(listOf(EntitiesTestHelper.basicWowEntity))
+
+        // getRunDetails should have been called exactly once across both syncs
+        verify(raiderIoClient, times(1)).getRunDetails(season.slug, run.runId.toString())
+
+        val cached = getCachedData(dataCacheRepository, EntitiesTestHelper.basicWowEntity.id)
+        assertEquals(EnrichedMythicPlusRun(run, runDetails), cached.mythicPlusBestRuns.first())
+    }
+
+    @Test
     fun `getRunDetails is called only once for the same run id across multiple entities`(): Unit = runBlocking {
         val run = RaiderIoHttpClientHelper.mythicPlusRun
         val runDetails = RaiderIoHttpClientHelper.runDetails


### PR DESCRIPTION
### Description

Avoid redundant getRunDetails calls across syncs

### Checklist

- [ ] I didn't add a changelog entry because this feature didn't need to update changelog
- [ ] I didn't add a single test because this feature didn't require unit testing
- [x] I have tested this feature in an environment (e.g., production, development, local)

*Please ensure you’ve met all the necessary criteria before submitting.*

---

*If the changelog checkbox is not checked, make sure to add an entry in `CHANGELOG.md`.*

*If the unit testing is not checked, make sure to add unit tests in `/src/test/kotlin`.*