### PR TITLE
sanxei95 - Solved Postgres pool bottleneck and added concurrency when processing wow wowhc entities sync

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,6 +3,7 @@ export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=postgres
 export POSTGRES_DRIVER=org.postgresql.Driver
 export POSTGRES_URL=jdbc:postgresql://localhost:5432/raiderio_ladder?user=postgres&password=postgres
+export POSTGRES_MAX_POOL_SIZE=15
 export RIOT_API_KEY=******************************************
 export RAIDERIO_API_KEY=******************************************
 export JWT_SECRET=toalhitasWasHere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## [5.8.0] - 07-08-2026
+
+### Improved
+- **WoW and WoW HC sync now process entities concurrently**:
+    - Replaced the sequential `buffer(10).collect{}` entity loop (which never actually ran entities in parallel despite the naming) with `arrow.fx.coroutines.parMap`, bounded by `WOW_SYNC_CONCURRENCY` / `WOW_HC_SYNC_CONCURRENCY` (default 10 each).
+    - A rate-limiter timeout (`RequestNotPermitted`) on one entity no longer aborts the whole sync batch — it's now isolated as a per-entity error like any other sync failure.
+- **Database connection pool size increased**:
+    - `HikariConfig.maximumPoolSize` default raised from 3 to 10, configurable via `POSTGRES_MAX_POOL_SIZE`. The old hardcoded value was shared across all HTTP traffic and background sync work, causing endpoints to stall during sync.
+
+### Fixed
+- **Concurrent WoW sync crash on shared cached data**:
+    - Entities sharing a cached RaiderIO mythic+ run could crash the sync with `IllegalStateException: Flow invariant is violated` once entities were processed concurrently. Fixed by using `parMap`'s ordered variant instead of `parMapUnordered`, which avoids emitting from within the racing coroutine.
+
 ## [5.7.0] - 29-07-2026
 
 ### Added

--- a/src/main/kotlin/com/kos/Application.kt
+++ b/src/main/kotlin/com/kos/Application.kt
@@ -159,8 +159,14 @@ fun Application.module() {
         raiderIoHTTPClient,
         blizzardClient,
         wowItemsDatabaseRepository,
+        System.getenv("WOW_HC_SYNC_CONCURRENCY")?.toInt() ?: 10,
     )
-    val wowEntitySynchronizer = WowEntitySynchronizer(dataCacheRepository, raiderIoHTTPClient, seasonRepository)
+    val wowEntitySynchronizer = WowEntitySynchronizer(
+        dataCacheRepository,
+        raiderIoHTTPClient,
+        seasonRepository,
+        System.getenv("WOW_SYNC_CONCURRENCY")?.toInt() ?: 10,
+    )
 
     val entitySynchronizerProvider =
         EntitySynchronizerProvider(
@@ -230,9 +236,27 @@ fun Application.module() {
             CacheClearTaskRunner(tasksRepository, dataCacheService),
             UpdateWowHardcoreGuildsTaskRunner(tasksRepository, entitiesService),
             UpdateMythicPlusSeasonTaskRunner(tasksRepository, wowSeasonService),
-            CacheGameDataTaskRunner(Game.LOL, TaskType.CACHE_LOL_DATA_TASK, tasksRepository, syncEntitySelector, entitySynchronizerProvider),
-            CacheGameDataTaskRunner(Game.WOW, TaskType.CACHE_WOW_DATA_TASK, tasksRepository, syncEntitySelector, entitySynchronizerProvider),
-            CacheGameDataTaskRunner(Game.WOW_HC, TaskType.CACHE_WOW_HC_DATA_TASK, tasksRepository, syncEntitySelector, entitySynchronizerProvider),
+            CacheGameDataTaskRunner(
+                Game.LOL,
+                TaskType.CACHE_LOL_DATA_TASK,
+                tasksRepository,
+                syncEntitySelector,
+                entitySynchronizerProvider
+            ),
+            CacheGameDataTaskRunner(
+                Game.WOW,
+                TaskType.CACHE_WOW_DATA_TASK,
+                tasksRepository,
+                syncEntitySelector,
+                entitySynchronizerProvider
+            ),
+            CacheGameDataTaskRunner(
+                Game.WOW_HC,
+                TaskType.CACHE_WOW_HC_DATA_TASK,
+                tasksRepository,
+                syncEntitySelector,
+                entitySynchronizerProvider
+            ),
             CacheGameViewDataTaskRunner(
                 tasksRepository,
                 viewsService,

--- a/src/main/kotlin/com/kos/common/DatabaseFactory.kt
+++ b/src/main/kotlin/com/kos/common/DatabaseFactory.kt
@@ -12,6 +12,7 @@ object DatabaseFactory {
     private val user = System.getenv("POSTGRES_USER") ?: ""
     private val password = System.getenv("POSTGRES_PASSWORD") ?: ""
     private val driver = System.getenv("POSTGRES_DRIVER") ?: "org.h2.Driver"
+    private val maxPoolSize = System.getenv("POSTGRES_MAX_POOL_SIZE")?.toInt() ?: 10
 
     fun pooledDatabase(): Database {
 
@@ -21,7 +22,7 @@ object DatabaseFactory {
             config.jdbcUrl = url
             config.username = user
             config.password = password
-            config.maximumPoolSize = 3
+            config.maximumPoolSize = maxPoolSize
             config.isAutoCommit = false
             config.transactionIsolation = "TRANSACTION_REPEATABLE_READ"
             config.validate()

--- a/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wow/WowEntitySynchronizer.kt
@@ -2,6 +2,7 @@ package com.kos.sources.wow
 
 import arrow.core.Either
 import arrow.core.raise.either
+import arrow.fx.coroutines.parMap
 import com.kos.clients.ClientError
 import com.kos.clients.domain.*
 import com.kos.clients.raiderio.RaiderIoClient
@@ -9,6 +10,7 @@ import com.kos.clients.toSyncProcessingError
 import com.kos.common.DynamicCache
 import com.kos.common.WithLogger
 import com.kos.common.error.ServiceError
+import com.kos.common.error.SyncProcessingError
 import com.kos.datacache.DataCache
 import com.kos.datacache.repository.DataCacheRepository
 import com.kos.entities.domain.Entity
@@ -16,6 +18,9 @@ import com.kos.entities.domain.WowEntity
 import com.kos.entities.sync.EntitySynchronizer
 import com.kos.sources.wow.staticdata.wowseason.repository.WowSeasonRepository
 import com.kos.views.Game
+import io.github.resilience4j.ratelimiter.RequestNotPermitted
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.asFlow
@@ -36,6 +41,7 @@ class WowEntitySynchronizer(
     private val dataCacheRepository: DataCacheRepository,
     private val raiderIoClient: RaiderIoClient,
     private val wowSeasonRepository: WowSeasonRepository,
+    private val concurrency: Int = 10,
 ) : EntitySynchronizer, WithLogger("WowEntitySynchronizer") {
 
     override val game: Game = Game.WOW
@@ -49,6 +55,7 @@ class WowEntitySynchronizer(
         encodeDefaults = false
     }
 
+    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     override suspend fun synchronize(entities: List<Entity>): List<ServiceError> =
         coroutineScope {
             val wowEntities = entities.filterIsInstance<WowEntity>()
@@ -87,13 +94,14 @@ class WowEntitySynchronizer(
 
             val start = OffsetDateTime.now()
             wowEntities.asFlow()
-                .buffer(10)
-                .collect { entity ->
+                .parMap(concurrency = concurrency) { entity ->
                     synchronizeWowEntity(entity, currentSeasonSlug, cutoff, runDetailsCache)
-                        .fold(
-                            ifLeft = { errorsChannel.send(it) },
-                            ifRight = { dataChannel.send(it) }
-                        )
+                }
+                .collect { result ->
+                    result.fold(
+                        ifLeft = { errorsChannel.send(it) },
+                        ifRight = { dataChannel.send(it) }
+                    )
                 }
 
             errorsChannel.close()
@@ -103,7 +111,11 @@ class WowEntitySynchronizer(
             dataCollector.join()
 
             logger.info("Finished Caching Wow entities")
-            logger.debug("cached ${entities.size} entities in ${Duration.between(start, OffsetDateTime.now()).toMinutes()} minutes")
+            logger.debug(
+                "cached ${entities.size} entities in ${
+                    Duration.between(start, OffsetDateTime.now()).toMinutes()
+                } minutes"
+            )
             logger.debug("dynamic match cache hit rate: ${runDetailsCache.hitRate}%")
 
             errorsList
@@ -220,5 +232,9 @@ class WowEntitySynchronizer(
         operation: String,
         block: suspend () -> Either<ClientError, A>
     ): Either<ServiceError, A> =
-        block().mapLeft { it.toSyncProcessingError(operation) }
+        try {
+            block().mapLeft { it.toSyncProcessingError(operation) }
+        } catch (e: RequestNotPermitted) {
+            Either.Left(SyncProcessingError(operation, "Rate limiter timeout: ${e.message}"))
+        }
 }

--- a/src/main/kotlin/com/kos/sources/wowhc/WowHardcoreEntitySynchronizer.kt
+++ b/src/main/kotlin/com/kos/sources/wowhc/WowHardcoreEntitySynchronizer.kt
@@ -2,6 +2,7 @@ package com.kos.sources.wowhc
 
 import arrow.core.Either
 import arrow.core.raise.either
+import arrow.fx.coroutines.parMap
 import com.kos.clients.ClientError
 import com.kos.clients.HttpError
 import com.kos.clients.blizzard.BlizzardClient
@@ -22,6 +23,9 @@ import com.kos.entities.repository.EntitiesRepository
 import com.kos.entities.sync.EntitySynchronizer
 import com.kos.sources.wowhc.staticdata.wowitems.WowItemsDatabaseRepository
 import com.kos.views.Game
+import io.github.resilience4j.ratelimiter.RequestNotPermitted
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.asFlow
@@ -41,6 +45,7 @@ class WowHardcoreEntitySynchronizer(
     private val raiderIoClient: RaiderIoClient,
     private val blizzardClient: BlizzardClient,
     private val wowItemsDatabaseRepository: WowItemsDatabaseRepository,
+    private val concurrency: Int = 10,
 ) : EntitySynchronizer, WithLogger("WowHardcoreEntitySynchronizer") {
 
     override val game: Game = Game.WOW_HC
@@ -54,6 +59,7 @@ class WowHardcoreEntitySynchronizer(
         encodeDefaults = false
     }
 
+    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     override suspend fun synchronize(entities: List<Entity>): List<ServiceError> =
         coroutineScope {
             val wowEntities = entities.filterIsInstance<WowEntity>()
@@ -81,13 +87,14 @@ class WowHardcoreEntitySynchronizer(
             val start = OffsetDateTime.now()
             wowEntities
                 .asFlow()
-                .buffer(10)
-                .collect {
-                    synchronizeWowHcEntity(it)
-                        .fold(
-                            ifLeft = { errorChannel.send(it) },
-                            ifRight = { it?.let { dataChannel.send(it) } }
-                        )
+                .parMap(concurrency = concurrency) { entity ->
+                    synchronizeWowHcEntity(entity)
+                }
+                .collect { result ->
+                    result.fold(
+                        ifLeft = { errorChannel.send(it) },
+                        ifRight = { it?.let { dataChannel.send(it) } }
+                    )
                 }
 
             errorChannel.close()
@@ -283,6 +290,10 @@ class WowHardcoreEntitySynchronizer(
         operation: String,
         block: suspend () -> Either<ClientError, A>
     ): Either<ServiceError, A> =
-        block().mapLeft { it.toSyncProcessingError(operation) }
+        try {
+            block().mapLeft { it.toSyncProcessingError(operation) }
+        } catch (e: RequestNotPermitted) {
+            Either.Left(SyncProcessingError(operation, "Rate limiter timeout: ${e.message}"))
+        }
 
 }


### PR DESCRIPTION
### Description

  - Improved: WoW/WoW HC concurrent sync via parMap (with the WOW_SYNC_CONCURRENCY/WOW_HC_SYNC_CONCURRENCY knobs and per-entity RequestNotPermitted isolation), plus the DB pool default bump (3 → 10,           
  POSTGRES_MAX_POOL_SIZE).                                                                                                                                                                                       
  - Fixed: the parMapUnordered → parMap crash fix, described briefly without the full internal mechanism (that detail lives in the skill/memory now).

### Checklist

- [ ] I didn't add a changelog entry because this feature didn't need to update changelog
- [x] I didn't add a single test because this feature didn't require unit testing
- [x] I have tested this feature in an environment (e.g., production, development, local)

*Please ensure you’ve met all the necessary criteria before submitting.*

---

*If the changelog checkbox is not checked, make sure to add an entry in `CHANGELOG.md`.*

*If the unit testing is not checked, make sure to add unit tests in `/src/test/kotlin`.*